### PR TITLE
Add roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # murdle
+
+See docs/roadmap.md for the project roadmap.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,45 @@
+# Implementation Roadmap
+
+This roadmap outlines tasks for building the multiplayer Wordle app described in `docs/research.md`.
+
+## 1. Setup Repositories and Environment
+- Create separate front-end and back-end projects.
+- Bootstrap the React client using Create React App.
+- Initialize a Node.js server with Express and Socket.IO.
+- Configure CORS settings for local development.
+- Document Render deployment settings (build command and port).
+
+## 2. Implement Core Game Logic on Server
+- Define data structures to track players, rooms and game state.
+- Handle Socket.IO connection, disconnection and `joinGame` events.
+- Implement `startGame`, `guess` and `gameOver` events.
+- Load a word list for choosing the secret word.
+- Broadcast updates to all players in the default room.
+
+## 3. Build the Front-End UI and Components
+- Connect to the server using `socket.io-client`.
+- Create name/avatar entry modal and lobby player list.
+- Build the Wordle grid and on-screen keyboard.
+- Display guess results with color animations.
+- Keep keyboard letter states in sync with guesses.
+
+## 4. Polish the UI and User Experience
+- Apply responsive CSS for board and keyboard layout.
+- Add tile flip animations and optional sound effects.
+- Provide dark‑mode styling and avatar display tweaks.
+- Style the leaderboard/results modal.
+
+## 5. Deployment on Render
+- Deploy the static front-end and note its URL.
+- Deploy the Node back-end as a Web Service.
+- Set environment variables such as `REACT_APP_SOCKET_URL`.
+- Restrict CORS to the static site URL in production.
+- Test the deployed site with multiple clients.
+
+## Future Improvements
+- Support multiple rooms with unique codes.
+- Add timers or multi‑round tournaments.
+- Persist leaderboards or user accounts in a database.
+- Offer variant word lengths or additional Wordle modes.
+- Enhance polish with shareable results and accessibility options.
+


### PR DESCRIPTION
## Summary
- add roadmap with tasks derived from research plan
- update README to reference roadmap

## Testing
- `npm install`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687ea5f9be508323abcd12a80af3f9be