### PR TITLE
Implement basic lobby and Wordle UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+client/build
+server/node_modules
+client/node_modules
+.DS_Store

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-scripts": "5.0.1",
+        "socket.io-client": "^4.8.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -3189,6 +3190,12 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -6891,6 +6898,66 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -15010,6 +15077,68 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -17480,6 +17609,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
+    "socket.io-client": "^4.8.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,38 +1,10 @@
 .App {
   text-align: center;
+  padding: 20px;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.game {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,23 +1,112 @@
-import logo from './logo.svg';
+import React, { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+import NameModal from './components/NameModal';
+import Lobby from './components/Lobby';
+import WordleBoard from './components/WordleBoard';
+import Keyboard from './components/Keyboard';
 import './App.css';
 
+const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || 'http://localhost:3001';
+
 function App() {
+  const [socket, setSocket] = useState(null);
+  const [connected, setConnected] = useState(false);
+  const [player, setPlayer] = useState(null);
+  const [players, setPlayers] = useState([]);
+  const [inGame, setInGame] = useState(false);
+  const [guesses, setGuesses] = useState([]);
+  const [results, setResults] = useState([]);
+  const [currentGuess, setCurrentGuess] = useState('');
+  const [kbStates, setKbStates] = useState({});
+  const wordLength = 5;
+
+  useEffect(() => {
+    const s = io(SOCKET_URL, { transports: ['websocket'] });
+    setSocket(s);
+    s.on('connect', () => setConnected(true));
+    s.on('playerList', (list) => setPlayers(list));
+    s.on('gameStarted', ({ length }) => {
+      setInGame(true);
+      setGuesses([]);
+      setResults([]);
+      setCurrentGuess('');
+      setKbStates({});
+    });
+    s.on('guessResult', ({ guess, result }) => {
+      setGuesses((g) => [...g, guess]);
+      setResults((r) => [...r, result]);
+      updateKeyboardStates(result, guess);
+      setCurrentGuess('');
+    });
+    s.on('gameOver', () => {
+      setInGame(false);
+    });
+    return () => s.close();
+  }, []);
+
+  const updateKeyboardStates = (result, guess) => {
+    setKbStates((prev) => {
+      const next = { ...prev };
+      result.forEach((state, idx) => {
+        const letter = guess[idx];
+        const prevState = next[letter];
+        const order = { correct: 3, present: 2, absent: 1 };
+        if (!prevState || order[state] > order[prevState]) {
+          next[letter] = state;
+        }
+      });
+      return next;
+    });
+  };
+
+  const handleNameSubmit = ({ name, avatar }) => {
+    setPlayer({ name, avatar });
+    socket.emit('joinGame', { name, avatar });
+  };
+
+  const handleStartGame = () => {
+    socket.emit('startGame');
+  };
+
+  const handleKey = (key) => {
+    if (!inGame) return;
+    if (key === 'enter') {
+      if (currentGuess.length === wordLength) {
+        socket.emit('guess', currentGuess);
+      }
+    } else if (key === 'back') {
+      setCurrentGuess((g) => g.slice(0, -1));
+    } else if (/^[a-z]$/.test(key) && currentGuess.length < wordLength) {
+      setCurrentGuess((g) => g + key);
+    }
+  };
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Enter') handleKey('enter');
+      else if (e.key === 'Backspace') handleKey('back');
+      else if (/^[a-zA-Z]$/.test(e.key)) handleKey(e.key.toLowerCase());
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  });
+
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      {!player && <NameModal onSubmit={handleNameSubmit} />}
+      {player && !inGame && (
+        <Lobby players={players} onStart={handleStartGame} />
+      )}
+      {player && inGame && (
+        <div className="game">
+          <WordleBoard
+            guesses={guesses}
+            results={results}
+            currentGuess={currentGuess}
+          />
+          <Keyboard onKey={handleKey} states={kbStates} />
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders name entry modal', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Enter Name/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/client/src/components/Keyboard.css
+++ b/client/src/components/Keyboard.css
@@ -1,0 +1,30 @@
+.keyboard {
+  margin-top: 20px;
+}
+.kb-row {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 6px;
+}
+.key {
+  padding: 8px 6px;
+  margin: 0 2px;
+  min-width: 32px;
+  border: none;
+  border-radius: 4px;
+  background: #d3d6da;
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+.key.correct {
+  background: #6aaa64;
+  color: white;
+}
+.key.present {
+  background: #c9b458;
+  color: white;
+}
+.key.absent {
+  background: #787c7e;
+  color: white;
+}

--- a/client/src/components/Keyboard.js
+++ b/client/src/components/Keyboard.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import './Keyboard.css';
+
+const KEYS = [
+  ['q','w','e','r','t','y','u','i','o','p'],
+  ['a','s','d','f','g','h','j','k','l'],
+  ['enter','z','x','c','v','b','n','m','back']
+];
+
+export default function Keyboard({ onKey, states }) {
+  const handleClick = (key) => {
+    onKey(key);
+  };
+  return (
+    <div className="keyboard">
+      {KEYS.map((row, i) => (
+        <div key={i} className="kb-row">
+          {row.map((k) => (
+            <button
+              key={k}
+              className={`key ${states[k] || ''}`}
+              onClick={() => handleClick(k)}
+            >
+              {k === 'enter' ? 'Enter' : k === 'back' ? '⌫' : k}
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/Lobby.css
+++ b/client/src/components/Lobby.css
@@ -1,0 +1,21 @@
+.lobby {
+  padding: 20px;
+}
+
+.player-list {
+  list-style: none;
+  padding: 0;
+}
+
+.player-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}

--- a/client/src/components/Lobby.js
+++ b/client/src/components/Lobby.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import './Lobby.css';
+
+export default function Lobby({ players, onStart }) {
+  return (
+    <div className="lobby">
+      <h2>Lobby</h2>
+      <ul className="player-list">
+        {players.map((p) => (
+          <li key={p.id}>
+            {p.avatar && <img src={p.avatar} alt="" className="avatar" />}
+            {p.name} {p.solved && '✅'}
+          </li>
+        ))}
+      </ul>
+      <button onClick={onStart}>Start Game</button>
+    </div>
+  );
+}

--- a/client/src/components/NameModal.css
+++ b/client/src/components/NameModal.css
@@ -1,0 +1,29 @@
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.name-modal {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.name-modal input {
+  padding: 8px;
+}
+
+.name-modal button {
+  padding: 8px;
+}

--- a/client/src/components/NameModal.js
+++ b/client/src/components/NameModal.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import './NameModal.css';
+
+export default function NameModal({ onSubmit }) {
+  const [name, setName] = useState('');
+  const [avatar, setAvatar] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onSubmit({ name: name.trim(), avatar: avatar.trim() });
+  };
+
+  return (
+    <div className="modal-backdrop">
+      <form className="name-modal" onSubmit={handleSubmit}>
+        <h2>Enter Name</h2>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Your name"
+        />
+        <input
+          type="text"
+          value={avatar}
+          onChange={(e) => setAvatar(e.target.value)}
+          placeholder="Avatar URL (optional)"
+        />
+        <button type="submit">Join Game</button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/WordleBoard.css
+++ b/client/src/components/WordleBoard.css
@@ -1,0 +1,36 @@
+.board {
+  display: grid;
+  gap: 8px;
+}
+.row {
+  display: grid;
+  grid-template-columns: repeat(5, 40px);
+  gap: 4px;
+}
+.tile {
+  width: 40px;
+  height: 40px;
+  border: 2px solid #888;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  transition: background-color 0.3s;
+}
+.tile.correct {
+  background: #6aaa64;
+  color: white;
+  border-color: #6aaa64;
+}
+.tile.present {
+  background: #c9b458;
+  color: white;
+  border-color: #c9b458;
+}
+.tile.absent {
+  background: #787c7e;
+  color: white;
+  border-color: #787c7e;
+}

--- a/client/src/components/WordleBoard.js
+++ b/client/src/components/WordleBoard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import './WordleBoard.css';
+
+const ROWS = 6;
+const COLS = 5;
+
+export default function WordleBoard({ guesses, results, currentGuess }) {
+  const rows = [];
+  for (let i = 0; i < ROWS; i++) {
+    const guess = guesses[i] || '';
+    const res = results[i] || [];
+    const isCurrent = i === guesses.length;
+    const letters = [];
+    for (let j = 0; j < COLS; j++) {
+      const char = isCurrent ? currentGuess[j] || '' : guess[j] || '';
+      const state = res[j];
+      letters.push(
+        <div key={j} className={`tile ${state || ''}`}>{char}</div>
+      );
+    }
+    rows.push(
+      <div key={i} className="row">
+        {letters}
+      </div>
+    );
+  }
+  return <div className="board">{rows}</div>;
+}


### PR DESCRIPTION
## Summary
- build NameModal for entering a player name and avatar
- show Lobby with player list and start button
- create Wordle board and on-screen keyboard components
- connect front-end to server via socket.io-client
- update tests and ignore build artifacts

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687eaeadbbf88323aa19004feccab6da